### PR TITLE
trusted-fingerprint: fix for error log when known_hosts file doesn't exist

### DIFF
--- a/trusted-fingerprint/client/verify-fingerprint.sh
+++ b/trusted-fingerprint/client/verify-fingerprint.sh
@@ -22,7 +22,7 @@ if [[ -z "$host_key" ]]; then
 fi
 
 # Check if the hostname exists in known hosts
-if [[  $(grep -q "$hashed_hostname $USER_KEY_TYPE" $KNOWN_HOSTS; echo $?) -eq 0 ]]; then
+if [[  $(test -f "$KNOWN_HOSTS"  && grep -q "$hashed_hostname $USER_KEY_TYPE" $KNOWN_HOSTS; echo $?) -eq 0 ]]; then
     echo "Key found in known_hosts."
     exit 0
 else


### PR DESCRIPTION
in verify-fingerprint.sh we search for the hashed hostname in known_hosts file in the user's home directory without testing if the file actually exists. So adding a `test -f` for that.