### PR TITLE
increase timeout for keyscan

### DIFF
--- a/trusted-fingerprint/client/verify-fingerprint.sh
+++ b/trusted-fingerprint/client/verify-fingerprint.sh
@@ -7,7 +7,7 @@ TRUSTED_FINGERPRINT_SERVER_TOKEN=${4:-$TRUSTED_FINGERPRINT_SERVER_TOKEN}
 HOMEDIR=$(eval echo ~)
 KNOWN_HOSTS=${5:-"$HOMEDIR/.ssh/known_hosts"}
 USER_KEY_TYPE=$(echo $USER_KEY | cut -d " " -f 1)
-KEYSCAN_TIMEOUT=$(6:-60)
+KEYSCAN_TIMEOUT=${6:-60}
 
 hash_known_hosts=$(ssh -G * | awk '/hashknownhosts/ {print $2}')
 hashed_hostname=$HOST

--- a/trusted-fingerprint/client/verify-fingerprint.sh
+++ b/trusted-fingerprint/client/verify-fingerprint.sh
@@ -11,7 +11,7 @@ USER_KEY_TYPE=$(echo $USER_KEY | cut -d " " -f 1)
 hash_known_hosts=$(ssh -G * | awk '/hashknownhosts/ {print $2}')
 hashed_hostname=$HOST
 
-keyscan_output=$(ssh-keyscan -t $USER_KEY_TYPE $HOST 2> /dev/null)
+keyscan_output=$(ssh-keyscan -T 60 -t $USER_KEY_TYPE $HOST 2> /dev/null)
 [[ "$hash_known_hosts" == "yes" ]] && hashed_hostname=$(echo "$keyscan_output" | awk '{print $1}')
 host_key=$(echo "$keyscan_output" | awk '{print $3}')
 

--- a/trusted-fingerprint/client/verify-fingerprint.sh
+++ b/trusted-fingerprint/client/verify-fingerprint.sh
@@ -7,11 +7,12 @@ TRUSTED_FINGERPRINT_SERVER_TOKEN=${4:-$TRUSTED_FINGERPRINT_SERVER_TOKEN}
 HOMEDIR=$(eval echo ~)
 KNOWN_HOSTS=${5:-"$HOMEDIR/.ssh/known_hosts"}
 USER_KEY_TYPE=$(echo $USER_KEY | cut -d " " -f 1)
+KEYSCAN_TIMEOUT=$(6:-60)
 
 hash_known_hosts=$(ssh -G * | awk '/hashknownhosts/ {print $2}')
 hashed_hostname=$HOST
 
-keyscan_output=$(ssh-keyscan -T 60 -t $USER_KEY_TYPE $HOST 2> /dev/null)
+keyscan_output=$(ssh-keyscan -T $KEYSCAN_TIMEOUT -t $USER_KEY_TYPE $HOST 2> /dev/null)
 [[ "$hash_known_hosts" == "yes" ]] && hashed_hostname=$(echo "$keyscan_output" | awk '{print $1}')
 host_key=$(echo "$keyscan_output" | awk '{print $3}')
 

--- a/trusted-fingerprint/docker/app.py
+++ b/trusted-fingerprint/docker/app.py
@@ -26,7 +26,10 @@ class RequestHandler(BaseHTTPRequestHandler):
         key_type = event_body['KeyType']
 
         secret_token = os.environ['SECRET_TOKEN']
-        keyscan_timeout = os.environ['KEYSCAN_TIMEOUT'] or 60
+        try:
+            keyscan_timeout = os.environ['KEYSCAN_TIMEOUT']
+        except:
+            keyscan_timeout = 60
 
         if len(auth) != 2 or auth[0] != "Bearer" or auth[1] != secret_token:
             self._set_headers(403)

--- a/trusted-fingerprint/docker/app.py
+++ b/trusted-fingerprint/docker/app.py
@@ -1,4 +1,5 @@
 import paramiko
+import socket
 import json
 import os
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -32,9 +33,10 @@ class RequestHandler(BaseHTTPRequestHandler):
             return
 
         try:
-            transport = paramiko.Transport(host)
+            sock = socket.create_connection((host, 22), timeout=60)
+            transport = paramiko.Transport(sock)
             transport.get_security_options().key_types = [key_type]
-            transport.connect()
+            transport.start_client()
 
             key = transport.get_remote_server_key()
             key_body = key.get_base64()

--- a/trusted-fingerprint/docker/app.py
+++ b/trusted-fingerprint/docker/app.py
@@ -53,7 +53,6 @@ class RequestHandler(BaseHTTPRequestHandler):
             self._set_headers(500)
             self.wfile.write(json.dumps({'body': 'Internal Server Error'}).encode())
         finally:
-            sock.shutdown()
             sock.close()
 
 

--- a/trusted-fingerprint/lambda/server.py
+++ b/trusted-fingerprint/lambda/server.py
@@ -3,36 +3,38 @@ import json
 import os
 import socket
 
+
 def lambda_handler(event, context):
     try:
         event_body = json.loads(event['body'])
-        
+
         if 'Authorization' not in event_body:
             return {
                 'statusCode': 403,
                 'body': 'Forbidden'
             }
-        
+
         auth = event_body['Authorization'].split()
         host = event_body['Host']
         key_type = event_body['KeyType']
-        
+
         secret_token = os.environ['SECRET_TOKEN']
-        
+        keyscan_timeout = os.environ['KEYSCAN_TIMEOUT'] or 60
+
         if len(auth) != 2 or auth[0] != "Bearer" or auth[1] != secret_token:
             return {
                 'statusCode': 403,
                 'body': 'Forbidden'
             }
-        
-        sock = socket.create_connection((host, 22), timeout=60)
+
+        sock = socket.create_connection((host, 22), timeout=keyscan_timeout)
         transport = paramiko.Transport(sock)
         transport.get_security_options().key_types = [key_type]
         transport.start_client()
-        
+
         key = transport.get_remote_server_key()
         key_body = key.get_base64()
-        
+
         transport.close()
 
         return {
@@ -44,3 +46,6 @@ def lambda_handler(event, context):
             'statusCode': 500,
             'body': 'Internal Server Error '
         }
+    finally:
+        sock.shutdown()
+        sock.close()

--- a/trusted-fingerprint/lambda/server.py
+++ b/trusted-fingerprint/lambda/server.py
@@ -50,5 +50,4 @@ def lambda_handler(event, context):
             'body': 'Internal Server Error '
         }
     finally:
-        sock.shutdown()
         sock.close()

--- a/trusted-fingerprint/lambda/server.py
+++ b/trusted-fingerprint/lambda/server.py
@@ -19,7 +19,10 @@ def lambda_handler(event, context):
         key_type = event_body['KeyType']
 
         secret_token = os.environ['SECRET_TOKEN']
-        keyscan_timeout = os.environ['KEYSCAN_TIMEOUT'] or 60
+        try:
+            keyscan_timeout = os.environ['KEYSCAN_TIMEOUT']
+        except:
+            keyscan_timeout = 60
 
         if len(auth) != 2 or auth[0] != "Bearer" or auth[1] != secret_token:
             return {

--- a/trusted-fingerprint/lambda/server.py
+++ b/trusted-fingerprint/lambda/server.py
@@ -1,6 +1,7 @@
 import paramiko
 import json
 import os
+import socket
 
 def lambda_handler(event, context):
     try:
@@ -24,9 +25,10 @@ def lambda_handler(event, context):
                 'body': 'Forbidden'
             }
         
-        transport = paramiko.Transport(host)
+        sock = socket.create_connection((host, 22), timeout=60)
+        transport = paramiko.Transport(sock)
         transport.get_security_options().key_types = [key_type]
-        transport.connect()
+        transport.start_client()
         
         key = transport.get_remote_server_key()
         key_body = key.get_base64()


### PR DESCRIPTION
## Description

Sometimes when a server is slow, it doesn't respond to keyscan because of which verify fingerprint script fails.