### PR TITLE
do not pipe keyscan output from verify fingeprint to /dev/null

### DIFF
--- a/trusted-fingerprint/client/verify-fingerprint.sh
+++ b/trusted-fingerprint/client/verify-fingerprint.sh
@@ -12,7 +12,7 @@ KEYSCAN_TIMEOUT=${6:-60}
 hash_known_hosts=$(ssh -G * | awk '/hashknownhosts/ {print $2}')
 hashed_hostname=$HOST
 
-keyscan_output=$(ssh-keyscan -T $KEYSCAN_TIMEOUT -t $USER_KEY_TYPE $HOST 2> /dev/null)
+keyscan_output=$(ssh-keyscan -T $KEYSCAN_TIMEOUT -t $USER_KEY_TYPE $HOST)
 [[ "$hash_known_hosts" == "yes" ]] && hashed_hostname=$(echo "$keyscan_output" | awk '{print $1}')
 host_key=$(echo "$keyscan_output" | awk '{print $3}')
 


### PR DESCRIPTION
#### Description

do not pipe keyscan output from verify fingeprint to /dev/null
