### PR TITLE
fix: filter out comment lines from ssh-keyscan output

### DIFF
--- a/trusted-fingerprint/client/verify-fingerprint.sh
+++ b/trusted-fingerprint/client/verify-fingerprint.sh
@@ -14,7 +14,7 @@ hashed_hostname=$HOST
 
 keyscan_output=$(ssh-keyscan -T $KEYSCAN_TIMEOUT -t $USER_KEY_TYPE $HOST)
 [[ "$hash_known_hosts" == "yes" ]] && hashed_hostname=$(echo "$keyscan_output" | awk '{print $1}')
-host_key=$(echo "$keyscan_output" | awk '{print $3}')
+host_key=$(echo "$keyscan_output" | grep -v "^#" | awk '{print $3}')
 
 # Check if the key is empty
 if [[ -z "$host_key" ]]; then
@@ -50,7 +50,7 @@ else
     lambda_response_key=$(cat $tempkeyfile)
     rm $tempkeyfile
 
-    if [[ 
+    if [[
         $host_key == $lambda_response_key
     ]]; then
         


### PR DESCRIPTION

#### Description

Filter out comment lines from ssh-keyscan output in verify-fingerprint.sh


